### PR TITLE
fix(tests): increase timeout margin in Timeout_FallbackToDefault_UsesDefaultWhenExceeded

### DIFF
--- a/tests/ExperimentFramework.Tests/EnterpriseCoverageTests.cs
+++ b/tests/ExperimentFramework.Tests/EnterpriseCoverageTests.cs
@@ -124,7 +124,7 @@ public sealed class EnterpriseCoverageTests
                 .AddDefaultTrial<SuccessService>("")
                 .AddTrial<SlowService>("slow")
                 .OnErrorRedirectAndReplayDefault())
-            .WithTimeout(TimeSpan.FromMilliseconds(100))
+            .WithTimeout(TimeSpan.FromMilliseconds(2000))
             .UseDispatchProxy();
 
         services.AddExperimentFramework(experiments);


### PR DESCRIPTION
## Root Cause

The Timeout_FallbackToDefault_UsesDefaultWhenExceeded test was failing intermittently on CI due to tight timing.

The test used a **100ms** timeout with SuccessService containing wait Task.Delay(10). Under CI load (1,852 tests + Docker container tests running concurrently), Task.Delay(10) occasionally exceeded the 100ms budget, causing the fallback trial itself to also timeout and the test to fail spuriously.

Error seen:
`
System.TimeoutException : Trial '' for ITestService.ExecuteAsync exceeded timeout of 100ms
`

## Fix

Increased the timeout from **100ms → 2000ms**. This still reliably times out SlowService (which has a 5000ms delay) while giving the SuccessService fallback (10ms delay) a 200× margin on loaded CI workers.

## Validation

- Build: ✅ passes
- Specific test: ✅ passes locally