### PR TITLE
fix(ci): exclude E2E tests from solution-wide test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           dotnet test ExperimentFramework.slnx \
             --configuration Release \
+            -p:ExcludeE2ETests=true \
             --collect:"XPlat Code Coverage" \
             --settings tests/ExperimentFramework.Tests/coverage.runsettings
 
@@ -210,6 +211,7 @@ jobs:
             --configuration Release \
             --no-build \
             --verbosity normal \
+            -p:ExcludeE2ETests=true \
             --collect:"XPlat Code Coverage" \
             --settings tests/ExperimentFramework.Tests/coverage.runsettings
 

--- a/tests/ExperimentFramework.E2E.Tests/ExperimentFramework.E2E.Tests.csproj
+++ b/tests/ExperimentFramework.E2E.Tests/ExperimentFramework.E2E.Tests.csproj
@@ -8,6 +8,10 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ExcludeE2ETests)' == 'true'">
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />


### PR DESCRIPTION
## Summary

- Adds a conditional `IsTestProject=false` MSBuild property to the E2E csproj that fires when `ExcludeE2ETests=true` is passed
- Updates `pr-checks` and `release` jobs to pass `-p:ExcludeE2ETests=true` to `dotnet test ExperimentFramework.slnx`
- Leaves the `e2e-tests` job unchanged — it continues to run against the E2E project directly

## Why

The 80 Reqnroll E2E tests fail in the main CI jobs because Playwright browsers aren't installed and no app server is running. They should only run in the dedicated `e2e-tests` job.

## Test plan

- [x] Ran `dotnet test ExperimentFramework.slnx --verbosity quiet -p:ExcludeE2ETests=true` locally — 2578 tests passed, E2E project not discovered, exit code 0
- [ ] Verify `pr-checks` job passes in CI
- [ ] Verify `e2e-tests` job still discovers and attempts to run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)