### PR TITLE
fix(pack): resolve NU5017 for analyzer packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,6 @@ jobs:
           --no-build
           --output ./artifacts
           /p:ContinuousIntegrationBuild=true
-          /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }}
-          /p:SymbolPackageFormat=snupkg
           /p:Version=${{ env.PACKAGE_VERSION }}
           /p:AssemblyVersion=${{ env.ASSEMBLY_VERSION }}
           /p:FileVersion=${{ env.FILE_VERSION }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,12 @@
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
+  <!-- Symbol packages for all non-analyzer projects -->
+  <PropertyGroup Condition="'$(PackageType)' != 'Analyzer'">
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
   <!-- Package version management for multi-targeting -->
   <PropertyGroup>
     <!-- Microsoft.Extensions.* versions that support .NET Standard 2.0 and .NET 8+ -->

--- a/src/ExperimentFramework.Generators/ExperimentFramework.Generators.csproj
+++ b/src/ExperimentFramework.Generators/ExperimentFramework.Generators.csproj
@@ -22,6 +22,7 @@
 
     <!-- Pack as development dependency analyzer -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>
 

--- a/src/ExperimentFramework.Plugins.Generators/ExperimentFramework.Plugins.Generators.csproj
+++ b/src/ExperimentFramework.Plugins.Generators/ExperimentFramework.Plugins.Generators.csproj
@@ -21,6 +21,7 @@
 
     <!-- Pack as development dependency analyzer -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>
 


### PR DESCRIPTION
## Summary

- Move `IncludeSymbols`/`SymbolPackageFormat` from CI `/p:` override into `Directory.Build.props` with `PackageType != Analyzer` condition
- Analyzer packages (source generators) have `IncludeBuildOutput=false` so snupkg generation fails with NU5017
- Non-analyzer packages still get symbol packages via Directory.Build.props
- Previously masked by `|| true` on the pack step

## Test plan

- [x] `dotnet pack` succeeds for `ExperimentFramework.Generators` (no snupkg)
- [x] `dotnet pack` succeeds for `ExperimentFramework.Plugins.Generators` (no snupkg)
- [x] `dotnet pack` succeeds for `ExperimentFramework` core (with snupkg)