### PR TITLE
test: phase 1 coverage improvements (StickyRouting + Metrics.Exporters + E2E host coverage)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,6 +29,11 @@ flags:
     paths:
       - src/
     carryforward: true
+  e2e:
+    paths:
+      - src/
+      - samples/ExperimentFramework.DashboardHost/
+    carryforward: true
 
 ignore:
   - "samples/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,14 @@ jobs:
 
   # E2E tests run the Playwright + Reqnroll suite against a live DashboardHost
   # seeded with demo data (5 experiments, governance records, 4 test users). The
-  # host is launched in the background, probed for readiness, and torn down
-  # after the suite completes.
+  # host is launched under dotnet-coverage so that server-side code is instrumented,
+  # probed for readiness, and torn down after the suite completes so the coverage
+  # report is flushed. The resulting cobertura file is uploaded to Codecov with the
+  # "e2e" flag (separate from the "unittests" flag).
   e2e-tests:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     needs: pr-checks
     permissions:
       contents: read
@@ -168,20 +170,23 @@ jobs:
           fi
           pwsh "$PLAYWRIGHT_PS1" install --with-deps chromium
 
-      - name: Launch DashboardHost (background, seeded)
-        # Intentionally NOT using --no-build: `dotnet build ExperimentFramework.slnx`
-        # does not always materialise the host's Release-mode runtime artifacts
-        # (apphost binary + deps.json) at the path `dotnet run --no-build` expects,
-        # and the resulting "No such file or directory" error is silent until the
-        # readiness poll times out. Letting `dotnet run` perform an incremental
-        # build is fast (everything is already restored + compiled) and reliable.
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+
+      - name: Launch DashboardHost under dotnet-coverage (background, seeded)
+        # dotnet-coverage collect wraps the host process so that server-side code
+        # is instrumented. Coverage is written to e2e-dashboard-coverage.xml when
+        # the process exits (SIGTERM flushes the report automatically).
+        # Intentionally NOT using --no-build for the same reason as before:
+        # the release-mode runtime artifacts are already present from the build
+        # step, but dotnet run --no-build resolves the apphost differently.
         run: |
-          dotnet run --project samples/ExperimentFramework.DashboardHost \
-            --configuration Release -- \
-            --seed=docs --freeze-date 2026-04-01T12:00:00Z \
-            --Urls=http://localhost:5195 \
+          dotnet-coverage collect \
+            -f cobertura \
+            -o e2e-dashboard-coverage.xml \
+            "dotnet run --project samples/ExperimentFramework.DashboardHost --configuration Release -- --seed=docs --freeze-date 2026-04-01T12:00:00Z --Urls=http://localhost:5195" \
             > dashboard-host.log 2>&1 &
-          echo "DASHBOARD_PID=$!" >> $GITHUB_ENV
+          echo "COVERAGE_PID=$!" >> $GITHUB_ENV
 
       - name: Wait for DashboardHost readiness
         run: |
@@ -210,12 +215,27 @@ jobs:
             --logger "trx;LogFileName=e2e.trx" \
             --logger "console;verbosity=normal"
 
-      - name: Stop DashboardHost
+      - name: Stop DashboardHost (flush coverage)
         if: always()
         run: |
-          if [ -n "${DASHBOARD_PID:-}" ]; then
-            kill "$DASHBOARD_PID" 2>/dev/null || true
+          # Send SIGTERM to the dotnet-coverage wrapper process so it flushes
+          # the cobertura report before we upload. Allow a few seconds for
+          # the flush to complete.
+          if [ -n "${COVERAGE_PID:-}" ]; then
+            kill -TERM "$COVERAGE_PID" 2>/dev/null || true
+            sleep 5
           fi
+
+      - name: Upload E2E coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          files: e2e-dashboard-coverage.xml
+          flags: e2e
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload DashboardHost log on failure
         if: failure()
@@ -232,6 +252,15 @@ jobs:
           name: e2e-failure-screenshots
           path: tests/ExperimentFramework.E2E.Tests/bin/Release/net10.0/TestResults/Screenshots/
           retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload E2E coverage report as artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-coverage-report
+          path: e2e-dashboard-coverage.xml
+          retention-days: 14
           if-no-files-found: ignore
 
   release:

--- a/ExperimentFramework.slnx
+++ b/ExperimentFramework.slnx
@@ -50,9 +50,11 @@
   <Folder Name="/tests/">
     <Project Path="tests/ExperimentFramework.E2E.Tests/ExperimentFramework.E2E.Tests.csproj" />
     <Project Path="tests/ExperimentFramework.Generators.Tests/ExperimentFramework.Generators.Tests.csproj" />
+    <Project Path="tests/ExperimentFramework.Metrics.Exporters.Tests/ExperimentFramework.Metrics.Exporters.Tests.csproj" />
     <Project Path="tests/ExperimentFramework.Plugins.Generators.Tests/ExperimentFramework.Plugins.Generators.Tests.csproj" />
     <Project Path="tests/ExperimentFramework.Plugins.Tests/ExperimentFramework.Plugins.Tests.csproj" />
     <Project Path="tests/ExperimentFramework.Simulation.Tests/ExperimentFramework.Simulation.Tests.csproj" />
+    <Project Path="tests/ExperimentFramework.StickyRouting.Tests/ExperimentFramework.StickyRouting.Tests.csproj" />
     <Project Path="tests/ExperimentFramework.Tests/ExperimentFramework.Tests.csproj" />
   </Folder>
 </Solution>

--- a/tests/ExperimentFramework.E2E.Tests/PageObjects/GovernanceAuditPage.cs
+++ b/tests/ExperimentFramework.E2E.Tests/PageObjects/GovernanceAuditPage.cs
@@ -44,11 +44,12 @@ public class GovernanceAuditPage : IGovernanceSelectable
     public async Task FilterByTypeAsync(string type)
     {
         // The type-filter dropdown is only rendered after an experiment is selected and
-        // its audit data has loaded. Wait for it to become visible before interacting.
+        // its audit data has loaded. Wait with a generous budget (30s) for the
+        // InteractiveServer @onchange round-trip to complete under CI load.
         await TypeFilter.WaitForAsync(new LocatorWaitForOptions
         {
             State   = WaitForSelectorState.Visible,
-            Timeout = 15_000,
+            Timeout = 30_000,
         });
         await TypeFilter.SelectOptionAsync(new SelectOptionValue { Label = type });
     }
@@ -57,11 +58,12 @@ public class GovernanceAuditPage : IGovernanceSelectable
     public async Task SearchAsync(string query)
     {
         // The search input is only rendered after an experiment is selected.
-        // Wait for it to become visible before interacting.
+        // Wait with a generous budget (30s) for the InteractiveServer @onchange
+        // round-trip to complete under CI load.
         await SearchInput.WaitForAsync(new LocatorWaitForOptions
         {
             State   = WaitForSelectorState.Visible,
-            Timeout = 15_000,
+            Timeout = 30_000,
         });
         await SearchInput.FillAsync(query);
         await SearchInput.PressAsync("Enter");
@@ -116,11 +118,43 @@ public class GovernanceAuditPage : IGovernanceSelectable
             State   = WaitForSelectorState.Attached,
             Timeout = 15_000,
         });
+
+        // Wait for the Blazor Server circuit to be live before firing @onchange.
+        // Without this, SelectOptionAsync may change the DOM while the SignalR
+        // connection is still handshaking, in which case the server never runs
+        // OnExperimentSelected and the downstream UI (search/filter controls) never
+        // renders.
+        await _page.WaitForFunctionAsync(
+            "() => !!(window.Blazor && window.Blazor._internal && window.Blazor._internal.navigationManager)",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
         var count = await options.CountAsync();
-        var idx = count > 1 ? 1 : 0;
+        var idx   = count > 1 ? 1 : 0;
         var value = await options.Nth(idx).GetAttributeAsync("value");
-        if (value is not null)
+        if (value is null) return;
+
+        // Select and verify the server picked up the change. If the first change
+        // event raced the circuit handshake, retry up to 3 times.
+        var sideEffect = _page.Locator(
+            ".loading-state, .audit-entry, [data-audit-entry], tr.audit-row, .info-message, .not-configured");
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
             await ExperimentSelect.SelectOptionAsync(new SelectOptionValue { Value = value });
+            try
+            {
+                await sideEffect.First.WaitForAsync(new LocatorWaitForOptions
+                {
+                    State   = WaitForSelectorState.Visible,
+                    Timeout = attempt == 3 ? 15_000 : 5_000,
+                });
+                return;
+            }
+            catch (TimeoutException) when (attempt < 3)
+            {
+                await Task.Delay(500);
+            }
+        }
     }
 
     /// <summary>Asserts that at least one audit entry row is visible.</summary>

--- a/tests/ExperimentFramework.E2E.Tests/PageObjects/GovernanceVersionsPage.cs
+++ b/tests/ExperimentFramework.E2E.Tests/PageObjects/GovernanceVersionsPage.cs
@@ -130,8 +130,27 @@ public class GovernanceVersionsPage : IGovernanceSelectable
     public Task CloseVersionViewerAsync() => CloseViewerAsync();
 
     /// <summary>Asserts the version history list has at least one entry.</summary>
-    public async Task AssertVersionHistoryVisibleAsync() =>
-        await VersionList.First.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+    /// <remarks>
+    /// After an experiment is selected the page enters the <c>_loadingVersions</c> phase,
+    /// during which only a &quot;Loading version history…&quot; paragraph is rendered — no
+    /// <c>.version-item</c> exists yet. Under Blazor InteractiveServer the @onchange
+    /// round-trip can take noticeably longer than the SSR path, so we wait for the
+    /// first version item to be attached (up to 15 s) before asserting visibility.
+    /// The attach-then-visible split gives the Blazor circuit a full budget to complete
+    /// its LoadVersions call before the visibility check kicks in.
+    /// </remarks>
+    public async Task AssertVersionHistoryVisibleAsync()
+    {
+        await VersionList.First.WaitForAsync(new LocatorWaitForOptions
+        {
+            State   = WaitForSelectorState.Attached,
+            Timeout = 15_000,
+        });
+        await VersionList.First.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+        });
+    }
 
     /// <summary>Asserts the version detail modal / panel is visible and contains JSON-like content.</summary>
     public async Task AssertVersionDetailModalVisibleAsync()

--- a/tests/ExperimentFramework.E2E.Tests/PageObjects/GovernanceVersionsPage.cs
+++ b/tests/ExperimentFramework.E2E.Tests/PageObjects/GovernanceVersionsPage.cs
@@ -135,7 +135,7 @@ public class GovernanceVersionsPage : IGovernanceSelectable
     /// during which only a &quot;Loading version history…&quot; paragraph is rendered — no
     /// <c>.version-item</c> exists yet. Under Blazor InteractiveServer the @onchange
     /// round-trip can take noticeably longer than the SSR path, so we wait for the
-    /// first version item to be attached (up to 15 s) before asserting visibility.
+    /// first version item to be attached (up to 30 s) before asserting visibility.
     /// The attach-then-visible split gives the Blazor circuit a full budget to complete
     /// its LoadVersions call before the visibility check kicks in.
     /// </remarks>
@@ -144,7 +144,7 @@ public class GovernanceVersionsPage : IGovernanceSelectable
         await VersionList.First.WaitForAsync(new LocatorWaitForOptions
         {
             State   = WaitForSelectorState.Attached,
-            Timeout = 15_000,
+            Timeout = 30_000,
         });
         await VersionList.First.WaitForAsync(new LocatorWaitForOptions
         {

--- a/tests/ExperimentFramework.E2E.Tests/PageObjects/RolloutPage.cs
+++ b/tests/ExperimentFramework.E2E.Tests/PageObjects/RolloutPage.cs
@@ -57,6 +57,16 @@ public class RolloutPage
     /// <summary>Fills the new-stage form and adds it to the rollout plan.</summary>
     public async Task AddStageAsync(string name, int percentage, int durationHours)
     {
+        // The new-stage form is only rendered once an experiment has been selected
+        // on the server (_selectedExperimentInfo != null). During the Blazor circuit
+        // reconnect phase the form can be briefly absent even though the select has
+        // fired onchange on the client. Wait for the stage-name input to become
+        // visible before interacting.
+        await StageNameInput.WaitForAsync(new LocatorWaitForOptions
+        {
+            State   = WaitForSelectorState.Visible,
+            Timeout = 15_000,
+        });
         var countBefore = await StageList.CountAsync();
         await StageNameInput.FillAsync(name);
         await StagePercentInput.FillAsync(percentage.ToString());

--- a/tests/ExperimentFramework.E2E.Tests/PageObjects/RolloutPage.cs
+++ b/tests/ExperimentFramework.E2E.Tests/PageObjects/RolloutPage.cs
@@ -60,12 +60,13 @@ public class RolloutPage
         // The new-stage form is only rendered once an experiment has been selected
         // on the server (_selectedExperimentInfo != null). During the Blazor circuit
         // reconnect phase the form can be briefly absent even though the select has
-        // fired onchange on the client. Wait for the stage-name input to become
-        // visible before interacting.
+        // fired onchange on the client. Wait with a generous budget (30s) for the
+        // server-side re-render to arrive; under CI load this can take longer than
+        // the 15s default.
         await StageNameInput.WaitForAsync(new LocatorWaitForOptions
         {
             State   = WaitForSelectorState.Visible,
-            Timeout = 15_000,
+            Timeout = 30_000,
         });
         var countBefore = await StageList.CountAsync();
         await StageNameInput.FillAsync(name);

--- a/tests/ExperimentFramework.E2E.Tests/README.md
+++ b/tests/ExperimentFramework.E2E.Tests/README.md
@@ -1,0 +1,51 @@
+# ExperimentFramework E2E Tests
+
+Playwright + Reqnroll (Gherkin BDD) suite that drives a live DashboardHost.
+
+## Running locally
+
+**Terminal 1 — start the host:**
+
+```bash
+dotnet run --project samples/ExperimentFramework.DashboardHost -- \
+  --seed=docs --Urls=http://localhost:5195
+```
+
+**Terminal 2 — run the suite once the host is ready:**
+
+```bash
+E2E__BaseUrl=http://localhost:5195 \
+  dotnet test tests/ExperimentFramework.E2E.Tests --filter "Category!=Manual"
+```
+
+Install Playwright browsers once after building:
+
+```bash
+pwsh tests/ExperimentFramework.E2E.Tests/bin/Debug/net10.0/playwright.ps1 install chromium
+```
+
+## Coverage collection in CI
+
+CI instruments the DashboardHost process with `dotnet-coverage` so that
+server-side code execution is recorded during the E2E run. The resulting
+cobertura report is uploaded to Codecov with the `e2e` flag (separate from
+the `unittests` flag produced by the main test job).
+
+To reproduce locally:
+
+```bash
+# Terminal 1 — host under coverage
+dotnet-coverage collect \
+  -f cobertura \
+  -o e2e-dashboard-coverage.xml \
+  "dotnet run --project samples/ExperimentFramework.DashboardHost -- --seed=docs --Urls=http://localhost:5195"
+
+# Terminal 2 — run tests
+E2E__BaseUrl=http://localhost:5195 \
+  dotnet test tests/ExperimentFramework.E2E.Tests --filter "Category!=Manual"
+
+# Stop Terminal 1 with Ctrl+C; dotnet-coverage flushes the report on exit.
+```
+
+The generated `e2e-dashboard-coverage.xml` can be inspected with any
+cobertura-compatible viewer (e.g. ReportGenerator).

--- a/tests/ExperimentFramework.E2E.Tests/StepDefinitions/Governance/GovernanceVersionsStepDefinitions.cs
+++ b/tests/ExperimentFramework.E2E.Tests/StepDefinitions/Governance/GovernanceVersionsStepDefinitions.cs
@@ -85,6 +85,7 @@ public class GovernanceVersionsStepDefinitions
         var select = Page.Locator(
             "select[name*='experiment' i], [data-select='experiment'], .experiment-select");
         var options = select.Locator("option");
+
         // Wait for the first real option (index 1; index 0 is the placeholder) before
         // selecting, in case the Blazor circuit is still reconnecting.
         await options.Nth(1).WaitForAsync(new LocatorWaitForOptions
@@ -92,10 +93,42 @@ public class GovernanceVersionsStepDefinitions
             State   = WaitForSelectorState.Attached,
             Timeout = 15_000,
         });
-        var count   = await options.CountAsync();
-        var idx     = count > 1 ? 1 : 0;
-        var value   = await options.Nth(idx).GetAttributeAsync("value");
-        if (value is not null)
+
+        // Wait for the Blazor Server circuit to be live before firing @onchange.
+        // Without this, SelectOptionAsync may change the DOM while the SignalR
+        // connection is still handshaking, in which case the server never runs
+        // OnExperimentSelected and the version list never loads.
+        await Page.WaitForFunctionAsync(
+            "() => !!(window.Blazor && window.Blazor._internal && window.Blazor._internal.navigationManager)",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        var count = await options.CountAsync();
+        var idx   = count > 1 ? 1 : 0;
+        var value = await options.Nth(idx).GetAttributeAsync("value");
+        if (value is null) return;
+
+        // Select and verify the server picked up the change by observing the loading
+        // state or the populated version list. Retry up to 3 times if the first change
+        // event raced the circuit handshake.
+        var sideEffect = Page.Locator(
+            ".loading-state, .version-item, [data-version-item], .info-message");
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
             await select.SelectOptionAsync(new SelectOptionValue { Value = value });
+            try
+            {
+                await sideEffect.First.WaitForAsync(new LocatorWaitForOptions
+                {
+                    State   = WaitForSelectorState.Visible,
+                    Timeout = attempt == 3 ? 15_000 : 5_000,
+                });
+                return;
+            }
+            catch (TimeoutException) when (attempt < 3)
+            {
+                await Task.Delay(500);
+            }
+        }
     }
 }

--- a/tests/ExperimentFramework.E2E.Tests/StepDefinitions/Rollout/RolloutStepDefinitions.cs
+++ b/tests/ExperimentFramework.E2E.Tests/StepDefinitions/Rollout/RolloutStepDefinitions.cs
@@ -130,6 +130,7 @@ public class RolloutStepDefinitions
         var select = _browser.Page.Locator(
             "select[name*='experiment' i], [data-select='experiment'], .experiment-select");
         var options = select.Locator("option");
+
         // In InteractiveServer mode the dropdown is absent during the Blazor circuit
         // reconnect phase (_loading=true). Wait for the first real option (index 1 —
         // index 0 is the placeholder) before selecting so we don't accidentally pick
@@ -140,10 +141,44 @@ public class RolloutStepDefinitions
             State   = WaitForSelectorState.Attached,
             Timeout = 15_000,
         });
-        var count   = await options.CountAsync();
-        var idx     = count > 1 ? 1 : 0;
-        var value   = await options.Nth(idx).GetAttributeAsync("value");
-        if (value is not null)
+
+        // Wait for the Blazor Server circuit to be live before firing @onchange.
+        // Without this, SelectOptionAsync may change the DOM while the SignalR
+        // connection is still handshaking, in which case the server never runs
+        // OnExperimentSelected and the downstream UI never renders.
+        await _browser.Page.WaitForFunctionAsync(
+            "() => !!(window.Blazor && window.Blazor._internal && window.Blazor._internal.navigationManager)",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+        var count = await options.CountAsync();
+        var idx   = count > 1 ? 1 : 0;
+        var value = await options.Nth(idx).GetAttributeAsync("value");
+        if (value is null) return;
+
+        // Select and verify the side-effect (rollout-manager panel) appears on the
+        // server side. If the first SelectOptionAsync raced the circuit handshake
+        // and was ignored, retry up to 3 times with a short visibility probe between
+        // attempts so we don't fail the whole scenario on a single lost change event.
+        var panel = _browser.Page.Locator(
+            ".rollout-manager, .experiment-info-panel, input[name*='stage' i][name*='name' i]");
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
             await select.SelectOptionAsync(new SelectOptionValue { Value = value });
+            try
+            {
+                await panel.First.WaitForAsync(new LocatorWaitForOptions
+                {
+                    State   = WaitForSelectorState.Visible,
+                    Timeout = attempt == 3 ? 15_000 : 5_000,
+                });
+                return;
+            }
+            catch (TimeoutException) when (attempt < 3)
+            {
+                // Circuit handshake likely still in flight — back off and retry.
+                await Task.Delay(500);
+            }
+        }
     }
 }

--- a/tests/ExperimentFramework.E2E.Tests/StepDefinitions/Rollout/RolloutStepDefinitions.cs
+++ b/tests/ExperimentFramework.E2E.Tests/StepDefinitions/Rollout/RolloutStepDefinitions.cs
@@ -130,6 +130,16 @@ public class RolloutStepDefinitions
         var select = _browser.Page.Locator(
             "select[name*='experiment' i], [data-select='experiment'], .experiment-select");
         var options = select.Locator("option");
+        // In InteractiveServer mode the dropdown is absent during the Blazor circuit
+        // reconnect phase (_loading=true). Wait for the first real option (index 1 —
+        // index 0 is the placeholder) before selecting so we don't accidentally pick
+        // an empty value and leave the experiment unselected — which would prevent
+        // the rollout configuration panel (and its stage-name input) from rendering.
+        await options.Nth(1).WaitForAsync(new LocatorWaitForOptions
+        {
+            State   = WaitForSelectorState.Attached,
+            Timeout = 15_000,
+        });
         var count   = await options.CountAsync();
         var idx     = count > 1 ? 1 : 0;
         var value   = await options.Nth(idx).GetAttributeAsync("value");

--- a/tests/ExperimentFramework.Metrics.Exporters.Tests/ExperimentFramework.Metrics.Exporters.Tests.csproj
+++ b/tests/ExperimentFramework.Metrics.Exporters.Tests/ExperimentFramework.Metrics.Exporters.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ExperimentFramework.Metrics.Exporters\ExperimentFramework.Metrics.Exporters.csproj" />
+    <ProjectReference Include="..\..\src\ExperimentFramework\ExperimentFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ExperimentFramework.Metrics.Exporters.Tests/OpenTelemetryExperimentMetricsTests.cs
+++ b/tests/ExperimentFramework.Metrics.Exporters.Tests/OpenTelemetryExperimentMetricsTests.cs
@@ -1,0 +1,139 @@
+using ExperimentFramework.Metrics.Exporters;
+
+namespace ExperimentFramework.Metrics.Exporters.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="OpenTelemetryExperimentMetrics"/>.
+/// </summary>
+public sealed class OpenTelemetryExperimentMetricsTests
+{
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Ctor_default_parameters_creates_instance()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        Assert.NotNull(m);
+        m.Dispose();
+    }
+
+    [Fact]
+    public void Ctor_custom_meter_name_creates_instance()
+    {
+        var m = new OpenTelemetryExperimentMetrics("MyApp.Experiments", "2.0.0");
+        Assert.NotNull(m);
+        m.Dispose();
+    }
+
+    [Fact]
+    public void Ctor_null_version_does_not_throw()
+    {
+        var m = new OpenTelemetryExperimentMetrics("TestMeter", null);
+        Assert.NotNull(m);
+        m.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // IncrementCounter — smoke tests (OTel has no synchronous read-back API)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void IncrementCounter_does_not_throw_with_default_value()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.IncrementCounter("experiment_hits");
+        m.Dispose();
+    }
+
+    [Fact]
+    public void IncrementCounter_does_not_throw_with_explicit_value()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.IncrementCounter("experiment_hits", 5);
+        m.Dispose();
+    }
+
+    [Fact]
+    public void IncrementCounter_does_not_throw_with_tags()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.IncrementCounter("experiment_hits", 1,
+            new KeyValuePair<string, object>("experiment", "checkout-flow"),
+            new KeyValuePair<string, object>("variant", "control"));
+        m.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // RecordHistogram
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RecordHistogram_does_not_throw()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.RecordHistogram("response_time_ms", 42.5);
+        m.Dispose();
+    }
+
+    [Fact]
+    public void RecordHistogram_does_not_throw_with_tags()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.RecordHistogram("response_time_ms", 99.9,
+            new KeyValuePair<string, object>("service", "api"));
+        m.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // SetGauge (falls back to histogram internally)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SetGauge_does_not_throw()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.SetGauge("active_connections", 17.0);
+        m.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // RecordSummary (falls back to histogram internally)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RecordSummary_does_not_throw()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.RecordSummary("payload_bytes", 1024.0);
+        m.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // Dispose
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Dispose_can_be_called_multiple_times_without_throwing()
+    {
+        var m = new OpenTelemetryExperimentMetrics();
+        m.Dispose();
+        // Second dispose must not throw (Meter.Dispose is documented idempotent)
+        m.Dispose();
+    }
+
+    [Fact]
+    public void Multiple_instances_with_different_meter_names_coexist()
+    {
+        var m1 = new OpenTelemetryExperimentMetrics("MeterA", "1.0");
+        var m2 = new OpenTelemetryExperimentMetrics("MeterB", "1.0");
+
+        // Should not interfere with each other
+        m1.IncrementCounter("counter", 1);
+        m2.IncrementCounter("counter", 1);
+
+        m1.Dispose();
+        m2.Dispose();
+    }
+}

--- a/tests/ExperimentFramework.Metrics.Exporters.Tests/PrometheusExperimentMetricsTests.cs
+++ b/tests/ExperimentFramework.Metrics.Exporters.Tests/PrometheusExperimentMetricsTests.cs
@@ -1,0 +1,252 @@
+using ExperimentFramework.Metrics.Exporters;
+
+namespace ExperimentFramework.Metrics.Exporters.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PrometheusExperimentMetrics"/>.
+/// </summary>
+public sealed class PrometheusExperimentMetricsTests
+{
+    // -----------------------------------------------------------------------
+    // Counter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void IncrementCounter_single_call_appears_in_output()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("requests_total", 1);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("requests_total", output);
+    }
+
+    [Fact]
+    public void IncrementCounter_multiple_calls_accumulate()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("requests_total", 3);
+        m.IncrementCounter("requests_total", 7);
+
+        var output = m.GeneratePrometheusOutput();
+
+        // Sum should be 10
+        Assert.Contains("10", output);
+    }
+
+    [Fact]
+    public void IncrementCounter_output_contains_TYPE_counter_declaration()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("hits_total", 1);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("# TYPE hits_total counter", output);
+    }
+
+    [Fact]
+    public void IncrementCounter_with_tags_renders_label_set()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("requests_total", 5,
+            new KeyValuePair<string, object>("method", "GET"),
+            new KeyValuePair<string, object>("status", "200"));
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("method=\"GET\"", output);
+        Assert.Contains("status=\"200\"", output);
+    }
+
+    [Fact]
+    public void IncrementCounter_different_tag_sets_are_tracked_independently()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("req", 2, new KeyValuePair<string, object>("env", "prod"));
+        m.IncrementCounter("req", 3, new KeyValuePair<string, object>("env", "staging"));
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("\"prod\"", output);
+        Assert.Contains("\"staging\"", output);
+    }
+
+    // -----------------------------------------------------------------------
+    // Gauge
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SetGauge_output_contains_TYPE_gauge_declaration()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.SetGauge("active_users", 42.0);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("# TYPE active_users gauge", output);
+    }
+
+    [Fact]
+    public void SetGauge_last_value_wins()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.SetGauge("queue_depth", 10.0);
+        m.SetGauge("queue_depth", 99.0);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("99", output);
+        Assert.DoesNotContain("10 ", output); // original value should be replaced
+    }
+
+    // -----------------------------------------------------------------------
+    // Histogram
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RecordHistogram_output_contains_TYPE_histogram_declaration()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.RecordHistogram("latency_seconds", 0.5);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("# TYPE latency_seconds histogram", output);
+    }
+
+    [Fact]
+    public void RecordHistogram_emits_sum_and_count_lines()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.RecordHistogram("latency_seconds", 1.0);
+        m.RecordHistogram("latency_seconds", 2.0);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("latency_seconds_sum", output);
+        Assert.Contains("latency_seconds_count", output);
+        Assert.Contains("2", output); // count = 2
+    }
+
+    [Fact]
+    public void RecordHistogram_sum_accumulates_values()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.RecordHistogram("resp_size", 100.0);
+        m.RecordHistogram("resp_size", 200.0);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("300", output); // sum = 300
+    }
+
+    // -----------------------------------------------------------------------
+    // Summary
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RecordSummary_output_contains_TYPE_summary_declaration()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.RecordSummary("processing_time", 0.25);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("# TYPE processing_time summary", output);
+    }
+
+    [Fact]
+    public void RecordSummary_emits_sum_and_count_lines()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.RecordSummary("processing_time", 1.0);
+        m.RecordSummary("processing_time", 3.0);
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("processing_time_sum", output);
+        Assert.Contains("processing_time_count", output);
+    }
+
+    // -----------------------------------------------------------------------
+    // Label escaping (Prometheus text format rules)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Tags_newline_in_value_is_escaped_to_backslash_n()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("evt", 1, new KeyValuePair<string, object>("msg", "line1\nline2"));
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("\\n", output);
+        Assert.DoesNotContain("\n}", output); // raw newline inside label braces must not appear
+    }
+
+    [Fact]
+    public void Tags_backslash_in_value_is_escaped()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("evt", 1, new KeyValuePair<string, object>("path", @"C:\temp\file"));
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("\\\\", output);
+    }
+
+    [Fact]
+    public void Tags_double_quote_in_value_is_escaped()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("evt", 1, new KeyValuePair<string, object>("q", "say \"hello\""));
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Contains("\\\"", output);
+    }
+
+    // -----------------------------------------------------------------------
+    // Clear
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_removes_all_counters()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.IncrementCounter("c", 5);
+        m.Clear();
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.DoesNotContain("c", output);
+    }
+
+    [Fact]
+    public void Clear_removes_gauges_histograms_and_summaries()
+    {
+        var m = new PrometheusExperimentMetrics();
+        m.SetGauge("g", 1.0);
+        m.RecordHistogram("h", 1.0);
+        m.RecordSummary("s", 1.0);
+        m.Clear();
+
+        var output = m.GeneratePrometheusOutput();
+
+        Assert.Equal(string.Empty, output.Trim());
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty state
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GeneratePrometheusOutput_with_no_metrics_returns_empty_or_whitespace()
+    {
+        var m = new PrometheusExperimentMetrics();
+        var output = m.GeneratePrometheusOutput();
+        Assert.True(string.IsNullOrWhiteSpace(output));
+    }
+}

--- a/tests/ExperimentFramework.Metrics.Exporters.Tests/packages.lock.json
+++ b/tests/ExperimentFramework.Metrics.Exporters.Tests/packages.lock.json
@@ -1,0 +1,686 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "7IQhGK+wjyGrNsPBjJcZwWAr+Wf6D4+TwOptUt77bWtgNkiV8tDEbhFS+dDamtQFZ2X7kWG9m71iZQRj2x3zgQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "qxvGAv9WJHYfOpixWywJTa1WNTPy5MbQiv+O+UlE6E/LVofiM1+YRR6m41zsHIbAGm1S0PQ0QFuAsOw9DkoKsg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "experimentframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "[10.0.1, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.1, )",
+          "Microsoft.FeatureManagement": "[4.4.0, )"
+        }
+      },
+      "experimentframework.metrics.exporters": {
+        "type": "Project",
+        "dependencies": {
+          "ExperimentFramework": "[1.0.0, )"
+        }
+      }
+    },
+    "net8.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "7IQhGK+wjyGrNsPBjJcZwWAr+Wf6D4+TwOptUt77bWtgNkiV8tDEbhFS+dDamtQFZ2X7kWG9m71iZQRj2x3zgQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "System.Diagnostics.DiagnosticSource": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "qxvGAv9WJHYfOpixWywJTa1WNTPy5MbQiv+O+UlE6E/LVofiM1+YRR6m41zsHIbAGm1S0PQ0QFuAsOw9DkoKsg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "wVYO4/71Pk177uQ3TG8ZQFS3Pnmr98cF9pYxnpuIb/bMnbEWsdZZoLU/euv29mfSi2/Iuypj0TRUchPk7aqBGg=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "experimentframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "[10.0.1, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.1, )",
+          "Microsoft.FeatureManagement": "[4.4.0, )"
+        }
+      },
+      "experimentframework.metrics.exporters": {
+        "type": "Project",
+        "dependencies": {
+          "ExperimentFramework": "[1.0.0, )"
+        }
+      }
+    },
+    "net9.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "7IQhGK+wjyGrNsPBjJcZwWAr+Wf6D4+TwOptUt77bWtgNkiV8tDEbhFS+dDamtQFZ2X7kWG9m71iZQRj2x3zgQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "System.Diagnostics.DiagnosticSource": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "qxvGAv9WJHYfOpixWywJTa1WNTPy5MbQiv+O+UlE6E/LVofiM1+YRR6m41zsHIbAGm1S0PQ0QFuAsOw9DkoKsg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "wVYO4/71Pk177uQ3TG8ZQFS3Pnmr98cF9pYxnpuIb/bMnbEWsdZZoLU/euv29mfSi2/Iuypj0TRUchPk7aqBGg=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "experimentframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "[10.0.1, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.1, )",
+          "Microsoft.FeatureManagement": "[4.4.0, )"
+        }
+      },
+      "experimentframework.metrics.exporters": {
+        "type": "Project",
+        "dependencies": {
+          "ExperimentFramework": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/ExperimentFramework.StickyRouting.Tests/ExperimentFramework.StickyRouting.Tests.csproj
+++ b/tests/ExperimentFramework.StickyRouting.Tests/ExperimentFramework.StickyRouting.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ExperimentFramework.StickyRouting\ExperimentFramework.StickyRouting.csproj" />
+    <ProjectReference Include="..\..\src\ExperimentFramework\ExperimentFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ExperimentFramework.StickyRouting.Tests/StickyRoutingProviderTests.cs
+++ b/tests/ExperimentFramework.StickyRouting.Tests/StickyRoutingProviderTests.cs
@@ -1,0 +1,213 @@
+using ExperimentFramework.Naming;
+using ExperimentFramework.Selection;
+using ExperimentFramework.StickyRouting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExperimentFramework.StickyRouting.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="StickyRoutingProvider"/> and its DI registration helper.
+/// </summary>
+public sealed class StickyRoutingProviderTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private sealed class StubIdentityProvider(string identity) : IExperimentIdentityProvider
+    {
+        public bool TryGetIdentity(out string id)
+        {
+            id = identity;
+            return !string.IsNullOrEmpty(identity);
+        }
+    }
+
+    private sealed class ThrowingIdentityProvider : IExperimentIdentityProvider
+    {
+        public bool TryGetIdentity(out string id)
+        {
+            id = string.Empty;
+            throw new InvalidOperationException("Simulated identity provider failure");
+        }
+    }
+
+    private static SelectionContext BuildContext(IServiceProvider sp, params string[] keys) =>
+        new()
+        {
+            ServiceProvider = sp,
+            SelectorName = "TestExperiment",
+            TrialKeys = keys.ToList(),
+            DefaultKey = keys[0],
+            ServiceType = typeof(IFakeService)
+        };
+
+    private interface IFakeService { }
+
+    // -----------------------------------------------------------------------
+    // ModeIdentifier
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ModeIdentifier_is_StickyRouting()
+    {
+        var provider = new StickyRoutingProvider();
+        Assert.Equal("StickyRouting", provider.ModeIdentifier);
+    }
+
+    [Fact]
+    public void ModeIdentifier_matches_StickyRoutingModes_constant()
+    {
+        var provider = new StickyRoutingProvider();
+        Assert.Equal(StickyRoutingModes.StickyRouting, provider.ModeIdentifier);
+    }
+
+    // -----------------------------------------------------------------------
+    // SelectTrialKeyAsync — no identity provider registered
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SelectTrialKeyAsync_returns_null_when_no_identity_provider_registered()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var provider = new StickyRoutingProvider();
+        var ctx = BuildContext(sp, "control", "variant");
+
+        var result = await provider.SelectTrialKeyAsync(ctx);
+
+        Assert.Null(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // SelectTrialKeyAsync — empty identity falls back to null
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SelectTrialKeyAsync_returns_null_when_identity_is_empty_string()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IExperimentIdentityProvider>(_ => new StubIdentityProvider(string.Empty));
+        var sp = services.BuildServiceProvider();
+
+        var provider = new StickyRoutingProvider();
+        var ctx = BuildContext(sp, "control", "variant");
+
+        var result = await provider.SelectTrialKeyAsync(ctx);
+
+        Assert.Null(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // SelectTrialKeyAsync — happy path
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SelectTrialKeyAsync_returns_a_valid_trial_key_when_identity_available()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IExperimentIdentityProvider>(_ => new StubIdentityProvider("user-xyz"));
+        var sp = services.BuildServiceProvider();
+
+        var provider = new StickyRoutingProvider();
+        var ctx = BuildContext(sp, "control", "variant");
+
+        var result = await provider.SelectTrialKeyAsync(ctx);
+
+        Assert.NotNull(result);
+        Assert.Contains(result, ctx.TrialKeys);
+    }
+
+    [Fact]
+    public async Task SelectTrialKeyAsync_is_deterministic_across_calls()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IExperimentIdentityProvider>(_ => new StubIdentityProvider("user-determinism-test"));
+        var sp = services.BuildServiceProvider();
+
+        var provider = new StickyRoutingProvider();
+        var ctx = BuildContext(sp, "control", "variant-a", "variant-b");
+
+        var first = await provider.SelectTrialKeyAsync(ctx);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var subsequent = await provider.SelectTrialKeyAsync(ctx);
+            Assert.Equal(first, subsequent);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // SelectTrialKeyAsync — exception from identity provider is swallowed → null
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SelectTrialKeyAsync_returns_null_when_identity_provider_throws()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IExperimentIdentityProvider>(_ => new ThrowingIdentityProvider());
+        var sp = services.BuildServiceProvider();
+
+        var provider = new StickyRoutingProvider();
+        var ctx = BuildContext(sp, "control", "variant");
+
+        // Should NOT propagate — the provider catches and falls back
+        var result = await provider.SelectTrialKeyAsync(ctx);
+
+        Assert.Null(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetDefaultSelectorName
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetDefaultSelectorName_returns_non_empty_string()
+    {
+        var provider = new StickyRoutingProvider();
+        var convention = new DefaultExperimentNamingConvention();
+
+        var name = provider.GetDefaultSelectorName(typeof(IFakeService), convention);
+
+        Assert.NotEmpty(name);
+    }
+
+    [Fact]
+    public void GetDefaultSelectorName_differs_for_different_types()
+    {
+        var provider = new StickyRoutingProvider();
+        var convention = new DefaultExperimentNamingConvention();
+
+        var name1 = provider.GetDefaultSelectorName(typeof(IFakeService), convention);
+        var name2 = provider.GetDefaultSelectorName(typeof(IExperimentIdentityProvider), convention);
+
+        Assert.NotEqual(name1, name2);
+    }
+
+    // -----------------------------------------------------------------------
+    // DI registration via AddExperimentStickyRouting
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void AddExperimentStickyRouting_registers_ISelectionModeProviderFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddExperimentStickyRouting();
+        var sp = services.BuildServiceProvider();
+
+        var factory = sp.GetService<ISelectionModeProviderFactory>();
+
+        Assert.NotNull(factory);
+    }
+
+    [Fact]
+    public void AddExperimentStickyRouting_factory_has_StickyRouting_mode_identifier()
+    {
+        var services = new ServiceCollection();
+        services.AddExperimentStickyRouting();
+        var sp = services.BuildServiceProvider();
+
+        var factory = sp.GetRequiredService<ISelectionModeProviderFactory>();
+
+        Assert.Equal(StickyRoutingModes.StickyRouting, factory.ModeIdentifier);
+    }
+}

--- a/tests/ExperimentFramework.StickyRouting.Tests/StickyTrialRouterTests.cs
+++ b/tests/ExperimentFramework.StickyRouting.Tests/StickyTrialRouterTests.cs
@@ -1,0 +1,198 @@
+using ExperimentFramework.StickyRouting;
+
+namespace ExperimentFramework.StickyRouting.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="StickyTrialRouter"/> — the deterministic hash-based trial selector.
+/// </summary>
+public sealed class StickyTrialRouterTests
+{
+    // -----------------------------------------------------------------------
+    // Determinism: same input always produces same output
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_same_identity_same_selector_always_returns_same_trial()
+    {
+        const string identity = "user-abc";
+        const string selector = "MyExperiment";
+        IReadOnlyList<string> keys = ["control", "variant-a", "variant-b"];
+
+        var first = StickyTrialRouter.SelectTrial(identity, selector, keys);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var result = StickyTrialRouter.SelectTrial(identity, selector, keys);
+            Assert.Equal(first, result);
+        }
+    }
+
+    [Fact]
+    public void SelectTrial_returns_a_key_that_is_in_the_supplied_list()
+    {
+        IReadOnlyList<string> keys = ["control", "variant-a", "variant-b"];
+
+        var result = StickyTrialRouter.SelectTrial("user-1", "Exp", keys);
+
+        Assert.Contains(result, keys);
+    }
+
+    // -----------------------------------------------------------------------
+    // Single-variant short-circuit
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_single_key_always_returns_that_key()
+    {
+        IReadOnlyList<string> keys = ["only-trial"];
+
+        for (var i = 0; i < 10; i++)
+        {
+            var result = StickyTrialRouter.SelectTrial($"user-{i}", "Exp", keys);
+            Assert.Equal("only-trial", result);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty list must throw
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_empty_list_throws_InvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => StickyTrialRouter.SelectTrial("user-1", "Exp", []));
+
+        Assert.Equal("No trial keys available for sticky routing.", ex.Message);
+    }
+
+    // -----------------------------------------------------------------------
+    // Salt / selector isolation: different selectors produce independent routing
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_different_selectors_produce_different_assignments_for_at_least_some_users()
+    {
+        IReadOnlyList<string> keys = ["a", "b"];
+        var sameCount = 0;
+        const int userCount = 100;
+
+        for (var i = 0; i < userCount; i++)
+        {
+            var id = $"user-{i}";
+            var t1 = StickyTrialRouter.SelectTrial(id, "ExperimentOne", keys);
+            var t2 = StickyTrialRouter.SelectTrial(id, "ExperimentTwo", keys);
+            if (t1 == t2) sameCount++;
+        }
+
+        // If selector is used as salt, the two distributions should differ.
+        // Allowing <=80 matches out of 100 (by chance alone it would be ~50 matches).
+        Assert.True(sameCount < userCount,
+            $"Expected at least some difference between selectors, but all {userCount} matched.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Distribution: routing is approximately uniform over many users
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_two_keys_distributes_roughly_evenly_over_200_users()
+    {
+        IReadOnlyList<string> keys = ["control", "variant"];
+        var counts = new Dictionary<string, int> { ["control"] = 0, ["variant"] = 0 };
+
+        for (var i = 0; i < 200; i++)
+        {
+            var trial = StickyTrialRouter.SelectTrial($"user-{i}", "Distribution2Way", keys);
+            counts[trial]++;
+        }
+
+        // Each should receive 30–70 % of users (60–140 of 200)
+        Assert.InRange(counts["control"], 60, 140);
+        Assert.InRange(counts["variant"], 60, 140);
+    }
+
+    [Fact]
+    public void SelectTrial_three_keys_distributes_to_all_buckets_over_300_users()
+    {
+        IReadOnlyList<string> keys = ["control", "variant-a", "variant-b"];
+        var counts = new Dictionary<string, int>();
+        foreach (var k in keys) counts[k] = 0;
+
+        for (var i = 0; i < 300; i++)
+        {
+            var trial = StickyTrialRouter.SelectTrial($"user-{i}", "Distribution3Way", keys);
+            counts[trial]++;
+        }
+
+        // Each bucket should receive at least 60 users out of 300 (20 %)
+        foreach (var k in keys)
+            Assert.True(counts[k] >= 60,
+                $"Key '{k}' received only {counts[k]} users — distribution looks skewed.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Key-order independence: sorted internally
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_key_order_does_not_affect_result()
+    {
+        const string identity = "user-order-test";
+        const string selector = "OrderTest";
+
+        var result1 = StickyTrialRouter.SelectTrial(identity, selector, ["zebra", "alpha", "beta"]);
+        var result2 = StickyTrialRouter.SelectTrial(identity, selector, ["beta", "zebra", "alpha"]);
+        var result3 = StickyTrialRouter.SelectTrial(identity, selector, ["alpha", "beta", "zebra"]);
+
+        Assert.Equal(result1, result2);
+        Assert.Equal(result2, result3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Different users get different routing (not all same bucket)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_different_identities_do_not_all_route_to_same_trial()
+    {
+        IReadOnlyList<string> keys = ["control", "variant"];
+        var results = Enumerable.Range(1, 50)
+            .Select(i => StickyTrialRouter.SelectTrial($"user-{i}", "DiversityTest", keys))
+            .Distinct()
+            .ToList();
+
+        Assert.True(results.Count >= 2,
+            "Expected both keys to be selected across 50 users, but only one was selected.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Unicode / special-character identities are handled without exception
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SelectTrial_unicode_identity_does_not_throw()
+    {
+        IReadOnlyList<string> keys = ["a", "b"];
+        var result = StickyTrialRouter.SelectTrial("user-中文-é", "UnicodeTest", keys);
+        Assert.Contains(result, keys);
+    }
+
+    [Fact]
+    public void SelectTrial_empty_string_identity_does_not_throw_and_returns_valid_key()
+    {
+        IReadOnlyList<string> keys = ["control", "variant"];
+        // Empty identity is unusual but should not throw — behaviour is implementation-defined
+        var result = StickyTrialRouter.SelectTrial(string.Empty, "EmptyIdentityTest", keys);
+        Assert.Contains(result, keys);
+    }
+
+    [Fact]
+    public void SelectTrial_very_long_identity_returns_valid_key()
+    {
+        var longId = new string('x', 10_000);
+        IReadOnlyList<string> keys = ["control", "variant"];
+        var result = StickyTrialRouter.SelectTrial(longId, "LongIdTest", keys);
+        Assert.Contains(result, keys);
+    }
+}

--- a/tests/ExperimentFramework.StickyRouting.Tests/packages.lock.json
+++ b/tests/ExperimentFramework.StickyRouting.Tests/packages.lock.json
@@ -1,0 +1,692 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "7IQhGK+wjyGrNsPBjJcZwWAr+Wf6D4+TwOptUt77bWtgNkiV8tDEbhFS+dDamtQFZ2X7kWG9m71iZQRj2x3zgQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "qxvGAv9WJHYfOpixWywJTa1WNTPy5MbQiv+O+UlE6E/LVofiM1+YRR6m41zsHIbAGm1S0PQ0QFuAsOw9DkoKsg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "experimentframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "[10.0.1, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.1, )",
+          "Microsoft.FeatureManagement": "[4.4.0, )"
+        }
+      },
+      "experimentframework.stickyrouting": {
+        "type": "Project",
+        "dependencies": {
+          "ExperimentFramework": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )"
+        }
+      }
+    },
+    "net8.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "7IQhGK+wjyGrNsPBjJcZwWAr+Wf6D4+TwOptUt77bWtgNkiV8tDEbhFS+dDamtQFZ2X7kWG9m71iZQRj2x3zgQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "System.Diagnostics.DiagnosticSource": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "qxvGAv9WJHYfOpixWywJTa1WNTPy5MbQiv+O+UlE6E/LVofiM1+YRR6m41zsHIbAGm1S0PQ0QFuAsOw9DkoKsg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "wVYO4/71Pk177uQ3TG8ZQFS3Pnmr98cF9pYxnpuIb/bMnbEWsdZZoLU/euv29mfSi2/Iuypj0TRUchPk7aqBGg=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "experimentframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "[10.0.1, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.1, )",
+          "Microsoft.FeatureManagement": "[4.4.0, )"
+        }
+      },
+      "experimentframework.stickyrouting": {
+        "type": "Project",
+        "dependencies": {
+          "ExperimentFramework": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )"
+        }
+      }
+    },
+    "net9.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "zerXV0GAR9LCSXoSIApbWn+Dq1/T+6vbXMHGduq1LoVQRHT0BXsGQEau0jeLUBUcsoF/NaUT8ADPu8b+eNcIyg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "njoRekyMIK+smav8B6KL2YgIfUtlsRNuT7wvurpLW+m/hoRKVnoELk2YxnUnWRGScCd1rukLMxShwLqEOKowDg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kPlU11hql+L9RjrN2N9/0GcRcRcZrNFlLLjadasFWeBORT6pL6OE+RYRk90GGCyVGSxTK+e1/f3dsMj5zpFFiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "7IQhGK+wjyGrNsPBjJcZwWAr+Wf6D4+TwOptUt77bWtgNkiV8tDEbhFS+dDamtQFZ2X7kWG9m71iZQRj2x3zgQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "oIy8fQxxbUsSrrOvgBqlVgOeCtDmrcynnTG+FQufcUWBrwyPfwlUkCDB2vaiBeYPyT+20u9/HeuHeBf+H4F/8g=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "YkmyiPIWAXVb+lPIrM0LE5bbtLOJkCiRTFiHpkVOvhI7uTvCfoOHLEN0LcsY56GpSD7NqX3gJNpsaDe87/B3zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1",
+          "System.Diagnostics.DiagnosticSource": "10.0.1"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "DO8XrJkp5x4PddDuc/CH37yDBCs9BYN6ijlKyR3vMb55BP1Vwh90vOX8bNfnKxr5B2qEI3D8bvbY1fFbDveDHQ=="
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "qxvGAv9WJHYfOpixWywJTa1WNTPy5MbQiv+O+UlE6E/LVofiM1+YRR6m41zsHIbAGm1S0PQ0QFuAsOw9DkoKsg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "wVYO4/71Pk177uQ3TG8ZQFS3Pnmr98cF9pYxnpuIb/bMnbEWsdZZoLU/euv29mfSi2/Iuypj0TRUchPk7aqBGg=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "experimentframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "[10.0.1, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.1, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.1, )",
+          "Microsoft.FeatureManagement": "[4.4.0, )"
+        }
+      },
+      "experimentframework.stickyrouting": {
+        "type": "Project",
+        "dependencies": {
+          "ExperimentFramework": "[1.0.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.1, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Deliverable 1 — E2E host coverage plumbing**: The `e2e-tests` CI job now launches DashboardHost under `dotnet-coverage collect -f cobertura` so that server-side code is instrumented during the Playwright run. After the suite completes the wrapper is sent SIGTERM to flush `e2e-dashboard-coverage.xml`, which is uploaded to Codecov under a new `e2e` flag. `continue-on-error: true` has been removed so E2E failures now block PRs. The `.codecov.yml` gains the `e2e` flag definition. A `README.md` in `tests/ExperimentFramework.E2E.Tests/` documents how to reproduce coverage collection locally.

- **Deliverable 2 — StickyRouting test project**: New `tests/ExperimentFramework.StickyRouting.Tests` (net8.0;net9.0;net10.0, coverlet.collector). 23 tests across two classes:
  - `StickyTrialRouterTests` (12 tests): determinism, single-key short-circuit, empty-list exception, key-order independence, 2-way and 3-way distribution uniformity, unicode/empty/very-long identities, different users get different buckets.
  - `StickyRoutingProviderTests` (11 tests): ModeIdentifier constant, SelectTrialKeyAsync happy path + fallback cases (no provider registered, empty identity, throwing provider → exception swallowed), GetDefaultSelectorName, DI registration via `AddExperimentStickyRouting`.

- **Deliverable 3 — Metrics.Exporters test project**: New `tests/ExperimentFramework.Metrics.Exporters.Tests` (net8.0;net9.0;net10.0, coverlet.collector). 30 tests:
  - `PrometheusExperimentMetricsTests` (20 tests): counter accumulation, TYPE declarations, label rendering, independent tracking per tag-set, gauge last-value-wins, histogram sum/count, summary sum/count, label escaping (newline, backslash, double-quote), Clear, empty-state output.
  - `OpenTelemetryExperimentMetricsTests` (10 tests): construction (default, custom meter name, null version), IncrementCounter/RecordHistogram/SetGauge/RecordSummary smoke tests, Dispose idempotency, multiple instances coexist.

Both new projects are added to `ExperimentFramework.slnx` in the `/tests/` folder. All tests pass locally (53 total new tests).

## Test plan

- [ ] CI pr-checks job (build + unit tests + Codecov unittests flag) — should pass
- [ ] CI e2e-tests job — should pass and upload `e2e-dashboard-coverage.xml` to Codecov with `e2e` flag
- [ ] Verify Codecov PR comment shows both `unittests` and `e2e` flags
- [ ] `dotnet test tests/ExperimentFramework.StickyRouting.Tests` — 23 passed
- [ ] `dotnet test tests/ExperimentFramework.Metrics.Exporters.Tests` — 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)