### PR TITLE
feat: dogfood PatternKit in decorator pipeline

### DIFF
--- a/docs/reference/core-concepts.md
+++ b/docs/reference/core-concepts.md
@@ -267,6 +267,8 @@ The proxy is created once per scope (for scoped services), but trials are resolv
 ## Decorator Pipeline
 
 Decorators wrap the execution of trials to provide cross-cutting concerns without modifying trial implementations.
+The runtime pipeline is composed with PatternKit's async chain primitive, but the public
+`IExperimentDecorator` and `IExperimentDecoratorFactory` contracts remain the integration surface for applications.
 
 ### How Decorators Work
 

--- a/src/ExperimentFramework/Decorators/DecoratorPipeline.cs
+++ b/src/ExperimentFramework/Decorators/DecoratorPipeline.cs
@@ -1,3 +1,5 @@
+using PatternKit.Behavioral.Chain;
+
 namespace ExperimentFramework.Decorators;
 
 /// <summary>
@@ -14,7 +16,7 @@ namespace ExperimentFramework.Decorators;
 /// </remarks>
 public sealed class DecoratorPipeline
 {
-    private readonly IExperimentDecorator[] _decorators;
+    private readonly AsyncActionChain<DecoratorInvocationState> _chain;
 
     /// <summary>
     /// Initializes a new decorator pipeline by creating decorators from the provided factories.
@@ -26,7 +28,10 @@ public sealed class DecoratorPipeline
     /// This ensures each decorator is created once for the pipeline instance.
     /// </remarks>
     public DecoratorPipeline(IEnumerable<IExperimentDecoratorFactory> factories, IServiceProvider sp)
-        => _decorators = factories.Select(f => f.Create(sp)).ToArray();
+    {
+        var decorators = factories.Select(f => f.Create(sp)).ToArray();
+        _chain = BuildChain(decorators);
+    }
 
     /// <summary>
     /// Executes the pipeline for a given invocation context synchronously.
@@ -42,19 +47,10 @@ public sealed class DecoratorPipeline
     /// </remarks>
     public object? Invoke(InvocationContext ctx, Func<object?> terminal)
     {
-        var next = (Func<ValueTask<object?>>)AsyncTerminal;
-
-        // Outer-to-inner in registration order.
-        for (var i = _decorators.Length - 1; i >= 0; i--)
-        {
-            var d = _decorators[i];
-            var capturedNext = next;
-            next = () => d.InvokeAsync(ctx, capturedNext);
-        }
-
-        return next().AsTask().GetAwaiter().GetResult();
-
-        ValueTask<object?> AsyncTerminal() => new(terminal());
+        return InvokeAsync(ctx, () => new ValueTask<object?>(terminal()))
+            .AsTask()
+            .GetAwaiter()
+            .GetResult();
     }
 
     /// <summary>
@@ -74,18 +70,47 @@ public sealed class DecoratorPipeline
     /// The returned task represents the entire decorated execution.
     /// </para>
     /// </remarks>
-    public ValueTask<object?> InvokeAsync(InvocationContext ctx, Func<ValueTask<object?>> terminal)
+    public async ValueTask<object?> InvokeAsync(InvocationContext ctx, Func<ValueTask<object?>> terminal)
     {
-        var next = terminal;
+        var state = new DecoratorInvocationState(ctx, terminal);
 
-        // Outer-to-inner in registration order.
-        for (var i = _decorators.Length - 1; i >= 0; i--)
+        await _chain.ExecuteAsync(state).ConfigureAwait(false);
+
+        return state.Result;
+    }
+
+    private static AsyncActionChain<DecoratorInvocationState> BuildChain(IReadOnlyList<IExperimentDecorator> decorators)
+    {
+        var builder = AsyncActionChain<DecoratorInvocationState>.Create();
+
+        foreach (var decorator in decorators)
         {
-            var d = _decorators[i];
-            var capturedNext = next;
-            next = () => d.InvokeAsync(ctx, capturedNext);
+            builder.Use(async (state, ct, next) =>
+            {
+                state.Result = await decorator.InvokeAsync(
+                    state.Context,
+                    async () =>
+                    {
+                        await next(state, ct).ConfigureAwait(false);
+                        return state.Result;
+                    }).ConfigureAwait(false);
+            });
         }
 
-        return next();
+        builder.Finally(async (state, _) =>
+        {
+            state.Result = await state.Terminal().ConfigureAwait(false);
+        });
+
+        return builder.Build();
+    }
+
+    private sealed class DecoratorInvocationState(
+        InvocationContext context,
+        Func<ValueTask<object?>> terminal)
+    {
+        public InvocationContext Context { get; } = context;
+        public Func<ValueTask<object?>> Terminal { get; } = terminal;
+        public object? Result { get; set; }
     }
 }

--- a/src/ExperimentFramework/ExperimentFramework.csproj
+++ b/src/ExperimentFramework/ExperimentFramework.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="PatternKit.Core" Version="0.147.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExperimentFramework/packages.lock.json
+++ b/src/ExperimentFramework/packages.lock.json
@@ -58,6 +58,12 @@
           "Microsoft.Extensions.Logging": "8.0.1"
         }
       },
+      "PatternKit.Core": {
+        "type": "Direct",
+        "requested": "[0.147.1, )",
+        "resolved": "0.147.1",
+        "contentHash": "fe5pVffLgFiMn0YLHymv7syjpMO88LbgoLAgi++LQOKHP7xpHbAIKlBHLI4g4m7ZX8BvW52z/C1dirY/ypL0EQ=="
+      },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
         "resolved": "8.0.1",
@@ -173,6 +179,12 @@
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
           "Microsoft.Extensions.Logging": "8.0.1"
         }
+      },
+      "PatternKit.Core": {
+        "type": "Direct",
+        "requested": "[0.147.1, )",
+        "resolved": "0.147.1",
+        "contentHash": "fe5pVffLgFiMn0YLHymv7syjpMO88LbgoLAgi++LQOKHP7xpHbAIKlBHLI4g4m7ZX8BvW52z/C1dirY/ypL0EQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -294,6 +306,12 @@
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
           "Microsoft.Extensions.Logging": "8.0.1"
         }
+      },
+      "PatternKit.Core": {
+        "type": "Direct",
+        "requested": "[0.147.1, )",
+        "resolved": "0.147.1",
+        "contentHash": "fe5pVffLgFiMn0YLHymv7syjpMO88LbgoLAgi++LQOKHP7xpHbAIKlBHLI4g4m7ZX8BvW52z/C1dirY/ypL0EQ=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",

--- a/tests/ExperimentFramework.Tests/DecoratorAndNamingTests.cs
+++ b/tests/ExperimentFramework.Tests/DecoratorAndNamingTests.cs
@@ -183,6 +183,69 @@ public sealed class DecoratorAndNamingTests(ITestOutputHelper output) : TinyBddX
         await sp.DisposeAsync();
     }
 
+    [Scenario("Decorator pipeline invokes sync terminal through PatternKit chain")]
+    [Fact]
+    public Task DecoratorPipeline_invokes_sync_terminal_through_patternkit_chain()
+        => Given("pipeline with a decorator", () =>
+        {
+            var executionOrder = new List<string>();
+            var decorator = new TestDecorator("D1", executionOrder);
+            var factory = new TestDecoratorFactory(decorator);
+            var sp = new ServiceCollection().BuildServiceProvider();
+            var pipeline = new DecoratorPipeline([factory], sp);
+            var context = new InvocationContext(typeof(ITestService), "Execute", "test-trial", []);
+
+            return new SyncPipelineScenario(sp, pipeline, context, executionOrder);
+        })
+        .When("invoke synchronous terminal", s =>
+        {
+            var result = s.Pipeline.Invoke(s.Context, () =>
+            {
+                s.ExecutionOrder.Add("terminal");
+                return "sync-result";
+            });
+
+            return s with { Result = result };
+        })
+        .Then("returns terminal result", s => Equals("sync-result", s.Result))
+        .And("preserves decorator order", s => s.ExecutionOrder.SequenceEqual(["D1-before", "terminal", "D1-after"]))
+        .Finally(s => s.ServiceProvider.Dispose())
+        .AssertPassed();
+
+    [Scenario("Decorator pipeline allows short circuiting decorators")]
+    [Fact]
+    public Task DecoratorPipeline_allows_short_circuiting_decorators()
+        => Given("pipeline with short circuiting decorator", () =>
+        {
+            var executionOrder = new List<string>();
+            var shortCircuit = new ShortCircuitDecorator("cached", executionOrder);
+            var laterDecorator = new TestDecorator("D2", executionOrder);
+            var sp = new ServiceCollection().BuildServiceProvider();
+            var pipeline = new DecoratorPipeline(
+                [
+                    new TestDecoratorFactory(shortCircuit),
+                    new TestDecoratorFactory(laterDecorator)
+                ],
+                sp);
+            var context = new InvocationContext(typeof(ITestService), "Execute", "test-trial", []);
+
+            return new SyncPipelineScenario(sp, pipeline, context, executionOrder);
+        })
+        .When("invoke pipeline", s =>
+        {
+            var result = s.Pipeline.Invoke(s.Context, () =>
+            {
+                s.ExecutionOrder.Add("terminal");
+                return "terminal-result";
+            });
+
+            return s with { Result = result };
+        })
+        .Then("returns short circuit result", s => Equals("cached", s.Result))
+        .And("does not invoke downstream decorators or terminal", s => s.ExecutionOrder.SequenceEqual(["short-circuit"]))
+        .Finally(s => s.ServiceProvider.Dispose())
+        .AssertPassed();
+
     [Scenario("Default naming convention generates feature flag names")]
     [Fact]
     public void DefaultNamingConvention_generates_feature_flag_names()
@@ -340,6 +403,24 @@ internal class TestDecorator(string name, List<string> log) : IExperimentDecorat
 internal class TestDecoratorFactory(IExperimentDecorator decorator) : IExperimentDecoratorFactory
 {
     public IExperimentDecorator Create(IServiceProvider serviceProvider) => decorator;
+}
+
+internal sealed class ShortCircuitDecorator(string result, List<string> log) : IExperimentDecorator
+{
+    public ValueTask<object?> InvokeAsync(InvocationContext context, Func<ValueTask<object?>> next)
+    {
+        log.Add("short-circuit");
+        return ValueTask.FromResult<object?>(result);
+    }
+}
+
+internal sealed record SyncPipelineScenario(
+    ServiceProvider ServiceProvider,
+    DecoratorPipeline Pipeline,
+    InvocationContext Context,
+    List<string> ExecutionOrder)
+{
+    public object? Result { get; init; }
 }
 
 internal class CustomTestNamingConvention : IExperimentNamingConvention


### PR DESCRIPTION
## Summary
- compose the experiment decorator pipeline with PatternKit.Core's async action chain
- preserve the existing decorator factory and invocation contracts
- add TinyBDD coverage for synchronous invocation and short-circuit behavior
- document the PatternKit-backed runtime pipeline

Refs #100.

## Validation
- dotnet build ExperimentFramework.slnx --configuration Release --no-restore
- dotnet test tests\\ExperimentFramework.Tests\\ExperimentFramework.Tests.csproj --configuration Release --framework net10.0 --no-build
- git diff --check